### PR TITLE
Update README.md to reflect connections

### DIFF
--- a/Tech-Lab-On-Campus/consumer/README.md
+++ b/Tech-Lab-On-Campus/consumer/README.md
@@ -15,6 +15,8 @@ Below are bullet points of the criteria:
 - Connection: When building your connection use a `URLParameters` object created by the code snippet below. This will create a connection object with parameters that allow your consumer client to connect to the docker container hosting your RMQ broker. 
 
 ```
+import os, pika
+
 conn_params = pika.URLParameters(os.environ["AMQP_URL"])
 connection = pika.BlockingConnection(parameters=con_params)
 ```

--- a/Tech-Lab-On-Campus/consumer/README.md
+++ b/Tech-Lab-On-Campus/consumer/README.md
@@ -12,8 +12,15 @@ Below are bullet points of the criteria:
 - setupRMQConnection Function: Establish connection to the RabbitMQ service, declare a queue and exchange, bind the binding key to the queue on the exchange and finally set up a callback function for receiving messages
 - onMessageCallback: Print the UTF-8 string message and then close the connection.
 - startConsuming:  Consumer should start listening for messages from the queue.
+- Connection: When building your connection use a `URLParameters` object created by the code snippet below. This will create a connection object with parameters that allow your consumer client to connect to the docker container hosting your RMQ broker. 
 
-###### [Note: Utilize the following resource to help instantiate the Producer Class: [RabbitMQ Tutorial](https://www.rabbitmq.com/tutorials/tutorial-one-python.html)]
+```
+conn_params = pika.URLParameters(os.environ["AMQP_URL"])
+connection = pika.BlockingConnection(parameters=con_params)
+```
+
+###### [Note: Utilize the following resource to help instantiate the Consumer Class: [RabbitMQ Tutorial](https://www.rabbitmq.com/tutorials/tutorial-one-python.html)]
+###### [Note: For more information on connections using Pika please refer to this [link](https://pika.readthedocs.io/en/stable/examples/using_urlparameters.html)
 
 ## Testing
 In order to verify that the consumer class was properly instantiated, we will use the provided  `consume.py`, and `publish.py` file from the previous section on the producer. Follow the below instructions:

--- a/Tech-Lab-On-Campus/producer/README.md
+++ b/Tech-Lab-On-Campus/producer/README.md
@@ -14,6 +14,8 @@ Below are bullet points of the criteria:
 - Connection: When building your connection use a `URLParameters` object created by the code snippet below. This will create a connection object with parameters that allow your producer client to connect to the docker container hosting your RMQ broker. 
 
 ```
+import os, pika
+
 conn_params = pika.URLParameters(os.environ["AMQP_URL"])
 connection = pika.BlockingConnection(parameters=con_params)
 ```

--- a/Tech-Lab-On-Campus/producer/README.md
+++ b/Tech-Lab-On-Campus/producer/README.md
@@ -10,9 +10,16 @@ Below are bullet points of the criteria:
 - Constructor: Save the two variables needed to instantiate the class.
 - Constructor: Call the setupRMQConnection function.
 - setupRMQConnection Function: Establish connection to the RabbitMQ service.
-- publishOrder:  Publish a simple UTF-8 string message from the parameter. 
+- publishOrder:  Publish a simple UTF-8 string message from the parameter.
+- Connection: When building your connection use a `URLParameters` object created by the code snippet below. This will create a connection object with parameters that allow your producer client to connect to the docker container hosting your RMQ broker. 
+
+```
+conn_params = pika.URLParameters(os.environ["AMQP_URL"])
+connection = pika.BlockingConnection(parameters=con_params)
+```
 
 ###### [Note: Utilize the following resource to help instantiate the Producer Class: [RabbitMQ Toturial](https://www.rabbitmq.com/tutorials/tutorial-one-python.html)]
+###### [Note: For more information on connections using Pika please refer to this [link](https://pika.readthedocs.io/en/stable/examples/using_urlparameters.html)
 
 ## Testing
 To test your producer class, we'll use Docker to set up a container running RabbitMQ. We'll then create a testing container where you can run the test code provided. To validate the messages are being sent, you'll utilize the RabbitMQ container's management web application.


### PR DESCRIPTION
Update README.md to explicitly state that connections should be built w/ URLParameters parameter. Leading away from localhost.

**Describe your changes**
Currently, candidates will refer to the canonical RMQ [tutorial](https://www.rabbitmq.com/tutorials/tutorial-one-python.html) which uses localhost for it's connections. This works fine when RMQ is setup locally but doesn't work naturally with our docker setup. This update is to tell candidates to build to connection using the URL Parameters using the environment variable provided docker. 

**Testing performed**
This is just to reflect the solution which has already been tested.

**Additional context**
The additional lines don't explain importing pika or the os libs but candidates are expected to understand how to import or review the error statements they may get via a copy paste of the two lines.