### PR TITLE
add missing `BACKEND_API_URL` env var

### DIFF
--- a/Tech-Lab-On-Campus/NewsFeed/docker-compose.yml
+++ b/Tech-Lab-On-Campus/NewsFeed/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - BACKEND_API_URL=http://0.0.0.0:8000
     volumes:
       - .:/workspace
     command: /bin/bash


### PR DESCRIPTION
The frontend is currently failing because the `BACKEND_API_URL` var is unset. This PR adds it to the docker-compose file.
